### PR TITLE
feat: add guidance interface at root

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -47,6 +47,10 @@ def require_session(request: Request) -> Dict[str, Any]:
         raise HTTPException(status_code=401, detail="LTI launch required")
     return request.session["lti"]
 
+@app.get("/", response_class=HTMLResponse)
+async def root(request: Request):
+    return templates.TemplateResponse("index.html", {"request": request, "base_url": settings.APP_BASE_URL})
+
 @app.get("/healthz")
 async def healthz():
     return {"ok": True}

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8" />
+    <title>Moodle File Transfer Tool</title>
+</head>
+<body>
+    <h1>Moodle File Transfer Tool</h1>
+    <p>This service must be launched from your Learning Management System via LTI&nbsp;1.3.</p>
+    <ol>
+        <li>Register this app as an LTI tool in your LMS using {{ base_url }} as the launch URL.</li>
+        <li>Launch the tool as an administrator to supply OAuth client details for your Moodle platform.</li>
+        <li>Authorize with Moodle when prompted and use the interface to queue course file transfers to Azure Blob Storage.</li>
+    </ol>
+    <p>Use the <code>/healthz</code> endpoint for a basic deployment check.</p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- serve a new instructional page from the `/` route
- describe how to register and launch the tool via LTI

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689669f8417c832c8846caf73468c8c5